### PR TITLE
Removing unnecessary conversions from stream back to iterator

### DIFF
--- a/src/main/java/nl/knaw/dans/prestaging/cli/LoadFromDataverseCommand.java
+++ b/src/main/java/nl/knaw/dans/prestaging/cli/LoadFromDataverseCommand.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class LoadFromDataverseCommand extends EnvironmentCommand<DdManagePrestagingConfiguration> {
@@ -83,15 +84,16 @@ public class LoadFromDataverseCommand extends EnvironmentCommand<DdManagePrestag
             log.info("No DOI provided, loading all published datasets");
             SearchOptions options = new SearchOptions();
             options.setTypes(Collections.singletonList(SearchItemType.dataset));
-            loaderProxy.loadFromDatasets(toDoiIterator(client.search().iterator("publicationStatus:\"Published\"", options)));
+            toDoiStream(client.search().iterator("publicationStatus:\"Published\"", options))
+                    .forEach(loaderProxy::loadFromDataset);
         } else {
             log.info("Loading from provided DOI {}", doi);
             loaderProxy.loadFromDataset(doi);
         }
     }
 
-    private Iterator<String> toDoiIterator(Iterator<ResultItem> iterator) {
+    private Stream<String> toDoiStream(Iterator<ResultItem> iterator) {
         Spliterator<ResultItem> spliterator = Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED);
-        return StreamSupport.stream(spliterator, false).map(ri -> ((DatasetResultItem) ri).getGlobalId()).iterator();
+        return StreamSupport.stream(spliterator, false).map(ri -> ((DatasetResultItem) ri).getGlobalId());
     }
 }

--- a/src/main/java/nl/knaw/dans/prestaging/core/BasicFileMetaLoader.java
+++ b/src/main/java/nl/knaw/dans/prestaging/core/BasicFileMetaLoader.java
@@ -27,11 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.persistence.PersistenceException;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.StreamSupport;
 
 public class BasicFileMetaLoader {
     private static final Logger log = LoggerFactory.getLogger(BasicFileMetaLoader.class);
@@ -47,12 +43,6 @@ public class BasicFileMetaLoader {
         this.dataverseClient = dataverseClient;
         this.failOnError = failOnError;
         this.includeEasyMigration = includeEasyMigration;
-    }
-
-    public void loadFromDatasets(Iterator<String> dois) {
-        log.trace("ENTER");
-        Spliterator<String> spliterator = Spliterators.spliteratorUnknownSize(dois, Spliterator.ORDERED);
-        StreamSupport.stream(spliterator, false).forEach(this::loadFromDataset);
     }
 
     public void loadFromDataset(String doi) {


### PR DESCRIPTION
NO JIRA

# Description of changes
@jo-pol made me aware that there were unnecessarsy conversions back from stream to iterator.

* Only converting from iterator to stream
* Removed the `loadFromDatasets`. Calling `loadFromDataset` repeatedly using `forEach` works just as well.


# Notify
@DANS-KNAW/dataversedans
