### PR TITLE
Simplified start up script using new class in dans-java-util

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-java-utils</artifactId>
-            <version>0.0.3</version>
+            <version>0.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-java-utils</artifactId>
-            <version>0.0.2</version>
+            <version>0.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/assembly/dist/bin/dd-manage-prestaging
+++ b/src/main/assembly/dist/bin/dd-manage-prestaging
@@ -5,12 +5,4 @@ BINPATH=$(command readlink -f $0 2> /dev/null || command grealpath $0 2> /dev/nu
 APPHOME=$(dirname  $(dirname $BINPATH))
 CONFIG_PATH=/etc/opt/dans.knaw.nl/$SCRIPTNAME/config.yml
 
-# If last_arg arg is config.yml, use that instead of the one in etc
-# See: https://stackoverflow.com/a/1853993
-# Note: last_arg must not start with a dash, otherwise basename will choke on it
-for last_arg; do true; done
-if [[ $last_arg =~ ^[^-].*$ ]] && [[ $(basename $last_arg) ==  config.yml ]]; then
-  CONFIG_PATH=""
-fi
-
-java -jar $APPHOME/bin/$SCRIPTNAME.jar "$@" $CONFIG_PATH
+java -Ddans.default.config=$CONFIG_PATH -jar $APPHOME/bin/$SCRIPTNAME.jar "$@"

--- a/src/main/java/nl/knaw/dans/prestaging/cli/FindOrphanedCommand.java
+++ b/src/main/java/nl/knaw/dans/prestaging/cli/FindOrphanedCommand.java
@@ -22,6 +22,7 @@ import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.setup.Environment;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
+import nl.knaw.dans.lib.util.DefaultConfigEnvironmentCommand;
 import nl.knaw.dans.prestaging.DdManagePrestagingConfiguration;
 import nl.knaw.dans.prestaging.core.*;
 import nl.knaw.dans.prestaging.db.BasicFileMetaDAO;
@@ -35,7 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-public class FindOrphanedCommand extends EnvironmentCommand<DdManagePrestagingConfiguration> {
+public class FindOrphanedCommand extends DefaultConfigEnvironmentCommand<DdManagePrestagingConfiguration> {
     private static final Logger log = LoggerFactory.getLogger(FindOrphanedCommand.class);
     private static final String outputFile = "outputFile";
     private final HibernateBundle<DdManagePrestagingConfiguration> hibernate;

--- a/src/main/java/nl/knaw/dans/prestaging/cli/LoadFromDataverseCommand.java
+++ b/src/main/java/nl/knaw/dans/prestaging/cli/LoadFromDataverseCommand.java
@@ -28,6 +28,7 @@ import nl.knaw.dans.lib.dataverse.SearchOptions;
 import nl.knaw.dans.lib.dataverse.model.search.DatasetResultItem;
 import nl.knaw.dans.lib.dataverse.model.search.ResultItem;
 import nl.knaw.dans.lib.dataverse.model.search.SearchItemType;
+import nl.knaw.dans.lib.util.DefaultConfigEnvironmentCommand;
 import nl.knaw.dans.prestaging.DdManagePrestagingConfiguration;
 import nl.knaw.dans.prestaging.core.BasicFileMetaLoader;
 import nl.knaw.dans.prestaging.db.BasicFileMetaDAO;
@@ -41,7 +42,7 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public class LoadFromDataverseCommand extends EnvironmentCommand<DdManagePrestagingConfiguration> {
+public class LoadFromDataverseCommand extends DefaultConfigEnvironmentCommand<DdManagePrestagingConfiguration> {
     private static final Logger log = LoggerFactory.getLogger(LoadFromDataverseCommand.class);
     private final HibernateBundle<DdManagePrestagingConfiguration> hibernate;
 


### PR DESCRIPTION
NO JIRA

# Description of changes
* Derive the command classes from `DefaultConfigEnvironmentCommand` which sets the `config.yml` by default to the value of system property `dans.default.config`.
* Pass in the location of the installed config file with `-Ddans.default.config` in the start-up script.

Note that you can now still override the default config by providing a `config.yml` as the last trailing arg. Also note that the command line help remains correct.

@jo-pol : although this is a worthwhile improvement on its own, I doubt that it will let you combine 0..* trailing arguments with `config.yml` as the last. Maybe it is easier to choose a different command line than to try and achieve that.

# How to test


# Related PRs
https://github.com/DANS-KNAW/dans-dev-tools/pull/9

# Notify
@DANS-KNAW/dataversedans
