### PR TITLE
DD-760 Changed --include-easy-migration to --exclude-easy-migration

### DIFF
--- a/src/main/java/nl/knaw/dans/prestaging/cli/LoadFromDataverseCommand.java
+++ b/src/main/java/nl/knaw/dans/prestaging/cli/LoadFromDataverseCommand.java
@@ -62,11 +62,11 @@ public class LoadFromDataverseCommand extends DefaultConfigEnvironmentCommand<Dd
                 .action(Arguments.storeTrue())
                 .dest("failOnError")
                 .help("Fail the run at the first error");
-        subparser.addArgument("--include-easy-migration")
+        subparser.addArgument("--exclude-easy-migration")
                 .type(Boolean.class)
                 .action(Arguments.storeTrue())
-                .dest("includeEasyMigration")
-                .help("Include easy-migration metadata files");
+                .dest("excludeEasyMigration")
+                .help("Exclude easy-migration metadata files");
 
     }
 
@@ -79,7 +79,7 @@ public class LoadFromDataverseCommand extends DefaultConfigEnvironmentCommand<Dd
         BasicFileMetaLoader loaderProxy = new UnitOfWorkAwareProxyFactory(hibernate).create(
                 BasicFileMetaLoader.class,
                 new Class[]{BasicFileMetaDAO.class, DataverseClient.class, Boolean.class, Boolean.class},
-                new Object[]{dao, client, namespace.getBoolean("failOnError"), namespace.getBoolean("includeEasyMigration")});
+                new Object[]{dao, client, namespace.getBoolean("failOnError"), namespace.getBoolean("excludeEasyMigration")});
         String doi = namespace.getString("doi");
         if (doi == null) {
             log.info("No DOI provided, loading all published datasets");

--- a/src/main/java/nl/knaw/dans/prestaging/core/BasicFileMetaLoader.java
+++ b/src/main/java/nl/knaw/dans/prestaging/core/BasicFileMetaLoader.java
@@ -35,14 +35,14 @@ public class BasicFileMetaLoader {
     private final BasicFileMetaDAO dao;
     private final DataverseClient dataverseClient;
     private final boolean failOnError;
-    private final boolean includeEasyMigration;
+    private final boolean excludeEasyMigration;
 
-    public BasicFileMetaLoader(BasicFileMetaDAO dao, DataverseClient dataverseClient, Boolean failOnError, Boolean includeEasyMigration) {
+    public BasicFileMetaLoader(BasicFileMetaDAO dao, DataverseClient dataverseClient, Boolean failOnError, Boolean excludeEasyMigration) {
         log.trace("ENTER");
         this.dao = dao;
         this.dataverseClient = dataverseClient;
         this.failOnError = failOnError;
-        this.includeEasyMigration = includeEasyMigration;
+        this.excludeEasyMigration = excludeEasyMigration;
     }
 
     public void loadFromDataset(String doi) {
@@ -75,7 +75,7 @@ public class BasicFileMetaLoader {
         log.trace("ENTER");
         int count = 0;
         for (FileMeta f : v.getFiles()) {
-            if (!includeEasyMigration && "easy-migration".equals(f.getDirectoryLabel())) {
+            if (excludeEasyMigration && "easy-migration".equals(f.getDirectoryLabel())) {
                 log.debug("Skipping easy-migration file");
                 continue;
             }


### PR DESCRIPTION
Fixes DD-760

# Description of changes
* Changes option `--include-easy-migration` to `--excluding-easy-migration` and implementes appropriate logic.

# How to test
Load basic file metas with and without `easy-migration-files`.

# Notify
@DANS-KNAW/dataversedans
