### PR TITLE
DD-761 add option --exclude-easy-migration to find-orphaned

### DIFF
--- a/src/main/java/nl/knaw/dans/prestaging/cli/FindOrphanedCommand.java
+++ b/src/main/java/nl/knaw/dans/prestaging/cli/FindOrphanedCommand.java
@@ -16,10 +16,10 @@
 package nl.knaw.dans.prestaging.cli;
 
 import io.dropwizard.Application;
-import io.dropwizard.cli.EnvironmentCommand;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.dropwizard.setup.Environment;
+import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import nl.knaw.dans.lib.util.DefaultConfigEnvironmentCommand;
@@ -53,6 +53,11 @@ public class FindOrphanedCommand extends DefaultConfigEnvironmentCommand<DdManag
                 .required(true)
                 .dest(outputFile)
                 .help("The file to write the orphan paths to");
+        subparser.addArgument("--exclude-easy-migration")
+                .type(Boolean.class)
+                .action(Arguments.storeTrue())
+                .dest("excludeEasyMigration")
+                .help("Exclude easy-migration metadata files");
     }
 
     @Override
@@ -65,7 +70,7 @@ public class FindOrphanedCommand extends DefaultConfigEnvironmentCommand<DdManag
             OrphanFinder finderProxy = new UnitOfWorkAwareProxyFactory(hibernate).create(
                     OrphanFinder.class,
                     new Class[]{List.class, CapturedStorageIdentifiers.class, OrphanRegister.class},
-                    new Object[]{configuration.getStorage().getNamespaces(), new CapturedStorageIdentifiersInDatabase(dao), register});
+                    new Object[]{configuration.getStorage().getNamespaces(), new CapturedStorageIdentifiersInDatabase(dao, namespace.getBoolean("excludeEasyMigration")), register});
             finderProxy.searchStorageDirs();
         }
     }

--- a/src/main/java/nl/knaw/dans/prestaging/core/CapturedStorageIdentifiersInDatabase.java
+++ b/src/main/java/nl/knaw/dans/prestaging/core/CapturedStorageIdentifiersInDatabase.java
@@ -20,18 +20,22 @@ import nl.knaw.dans.prestaging.db.BasicFileMetaDAO;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CapturedStorageIdentifiersInDatabase implements CapturedStorageIdentifiers {
     private final BasicFileMetaDAO basicFileMetaDAO;
+    private final boolean excludeEasyMigration;
 
-    public CapturedStorageIdentifiersInDatabase(BasicFileMetaDAO basicFileMetaDAO) {
+    public CapturedStorageIdentifiersInDatabase(BasicFileMetaDAO basicFileMetaDAO, boolean excludeEasyMigration) {
         this.basicFileMetaDAO = basicFileMetaDAO;
+        this.excludeEasyMigration = excludeEasyMigration;
     }
 
     @Override
     @UnitOfWork
     public List<String> getForDoi(String doi) {
         return basicFileMetaDAO.findByDoi(doi).stream()
+                .filter(bfm -> !excludeEasyMigration || !"easy-migration".equals(bfm.getDirectoryLabel()))
                 .map(BasicFileMetaEntity::getStorageIdentifier)
                 .distinct()
                 .collect(Collectors.toList());

--- a/src/test/java/nl/knaw/dans/prestaging/core/OrphanFinderTest.java
+++ b/src/test/java/nl/knaw/dans/prestaging/core/OrphanFinderTest.java
@@ -65,10 +65,4 @@ public class OrphanFinderTest {
         assertEquals(Collections.emptyList(), orphanRegister.getOrphans());
 
     }
-
-    // TODO: ignores cached, .orig and thumb files
-
-    // TODO: calculate DOI from path
-
-
 }


### PR DESCRIPTION
Fixes DD-761

# Description of changes
* Adds option `--exclude-easy-migration` to `find-orphaned` that makes the command skipped the orphans for with `directoryLabel` is `easy-migration`.

# How to test
1. Create a prestaging database that excludes the `easy-migration` files (making them orphans)
2. Remove Dataverse
3. Run `find-orphaned` with and without the new option. With the option the `easy-migration` files should not be included as orphans (even though they really are).


# Related PRs
* #3 

# Notify
@DANS-KNAW/dataversedans
